### PR TITLE
Add Repository Moved notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[Shopping Cart Plugins] – Fiuu WordPress-WooCommerce-WP eCommerce-ClassiPress
+=====================
+
+<img src="https://user-images.githubusercontent.com/38641542/74420753-eacb5600-4e86-11ea-9389-5427e4c6840d.jpg">
+
 # 🚚 Repository Moved
 
 This repository has been moved to a new location and is no longer actively maintained.
@@ -12,14 +17,10 @@ Thank you for your support.
 
 ---
 
-[Shopping Cart Plugins] – Fiuu WordPress-WooCommerce-WP eCommerce-ClassiPress
-=====================
-
-<img src="https://user-images.githubusercontent.com/38641542/74420753-eacb5600-4e86-11ea-9389-5427e4c6840d.jpg">
-
 Fiuu Plugin for Wordpress developed by Fiuu technical team.
 
 UPDATE NOTICE
 -----
 
 Latest WooCommerce-WP moved to new URL: https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_WooCommerce
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+# 🚚 Repository Moved
+
+This repository has been moved to a new location and is no longer actively maintained.
+
+👉 New repository: https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_WooCommerce
+
+Please update your bookmarks, clone URLs, and CI/CD configurations accordingly.
+
+All future updates, bug fixes, and feature enhancements will be published in the new repository.
+
+Thank you for your support.
+
+---
+
 [Shopping Cart Plugins] – Fiuu WordPress-WooCommerce-WP eCommerce-ClassiPress
 =====================
 
@@ -9,4 +23,3 @@ UPDATE NOTICE
 -----
 
 Latest WooCommerce-WP moved to new URL: https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_WooCommerce
-

--- a/README.md
+++ b/README.md
@@ -14,13 +14,3 @@ Please update your bookmarks, clone URLs, and CI/CD configurations accordingly.
 All future updates, bug fixes, and feature enhancements will be published in the new repository.
 
 Thank you for your support.
-
----
-
-Fiuu Plugin for Wordpress developed by Fiuu technical team.
-
-UPDATE NOTICE
------
-
-Latest WooCommerce-WP moved to new URL: https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_WooCommerce
-


### PR DESCRIPTION
## Summary
- Added "Repository Moved" notice to the top of README
- Informs users that this repository has been migrated to the FiuuPayment organisation
- Directs users to update their bookmarks, clone URLs, and CI/CD configurations

## Related Issue
Fixes documentation migration requested in GitLab issue #17.